### PR TITLE
install dotnet40 explicitly before dotnet48 to avoid occasional hung installation

### DIFF
--- a/install-files/bin/wasta-logos64-setup
+++ b/install-files/bin/wasta-logos64-setup
@@ -19,6 +19,7 @@
 #   2020-05-11 rik: adding sleep before launcher edits
 #   2020-05-18 rik: setting Downloads folder from xdg-user-dir
 #   2020-05-25 ndm: updating with tips from ferion11 install script
+#   2022-03-09 ndm: install dotnet40 before dotnet48 to avoid failures
 #
 # ==============================================================================
 
@@ -196,6 +197,7 @@ setup_prefix() {
         "corefonts" \
         "ddr=gdi" \
         "settings fontsmooth=rgb" \
+        "dotnet40" \
         "dotnet48" \
     )
     for i in "${installs[@]}"; do


### PR DESCRIPTION
Testing multiple iterations of installing dotnet48 directly in a clean wine 64-bit prefix showed that it failed 20% of the time (3/15 attempts). Trying dotnet40 explicitly, followed by dotnet48, was successful 10/10 times. This seems more reliable for end users.